### PR TITLE
Add logging feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 /testfiles
+*.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ bincode = { version = "2.0", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5.41", features = ["derive"] }
 once_cell = "1.21.3"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-appender = "0.2.3"
+tempfile = "3.20.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "processenv", "winbase"] }

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ sudo cp target/release/quickswitch /usr/local/bin/
 你也可以使用类似[env-logger](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)的环境变量指示日志级别（大小写忽略，不支持模块定向级别，环境变量优先级低于命令行参数）。
 
 **日志文件说明：**
-日志只能存放在文件中，日志路径不可用时将直接退出。文件不存在将被创建，若已存在将尝试追加。参数缺省时通过[tempfile](https://docs.rs/tempfile/latest/tempfile/)库创建临时文件，文件名格式为`qw-[date]-[pid].log`。
+日志只能存放在文件中，日志路径不可用时将直接退出。文件不存在将被创建，若已存在将尝试追加。参数缺省时通过[tempfile](https://docs.rs/tempfile/latest/tempfile/)库创建临时文件，文件名格式为`qw-[date]-[pid]-[rand].log`。
 
 - `Linux`和`macOS`：存放在环境变量`TMPDIR`、`TMP`、`TEMP`指定的目录，缺省时为`/tmp`
 - `Windows`：存放在`C:\Users\<Username>\AppData\Local\Temp`
@@ -287,10 +287,8 @@ sudo cp target/release/quickswitch /usr/local/bin/
 quickswitch -v
 
 # 启用DEBUG级别日志，指定日志文件
-quickswitch -vv ./debug.log
+quickswitch -vv --log_file ./debug.log
 
-# 启用TRACE级别日志，指定日志文件
-quickswitch -vvv /tmp/quickswitch.log
 ```
 
 ## 开发贡献

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ sudo cp target/release/quickswitch /usr/local/bin/
 - `crossterm`: 跨平台终端操作库
 - `anyhow`: 错误处理库
 - `tokio`: 异步运行时
+- `tracing`: 日志收集
 
 ## 故障排除
 
@@ -258,6 +259,39 @@ sudo cp target/release/quickswitch /usr/local/bin/
    - 确保修改了脚本中的 quickswitch 路径
    - 确保重新加载了 shell 配置
    - 检查可执行文件权限
+
+### 日志
+
+日志功能由[tracing](https://github.com/tokio-rs/tracing)实现，使用以下参数启动日志。有关日志级别详见[tracing::Level](https://docs.rs/tracing/latest/tracing/struct.Level.html)。
+
+**日志级别参数：**
+- `-v/--verbose` 收集INFO级别日志
+- `-vv` 收集DEBUG级别日志
+- `-vvv` 收集TRACE级别日志
+
+**日志文件路径：**
+- `-v/-vv/-vvv/--verbose` 在设定日志级别的同时指定日志文件路径
+
+**环境变量支持：**
+你也可以使用类似[env-logger](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)的环境变量指示日志级别（大小写忽略，不支持模块定向级别，环境变量优先级低于命令行参数）。
+
+**日志文件说明：**
+日志只能存放在文件中，日志路径不可用时将直接退出。文件不存在将被创建，若已存在将尝试追加。参数缺省时通过[tempfile](https://docs.rs/tempfile/latest/tempfile/)库创建临时文件，文件名格式为`qw-[date]-[pid].log`。
+
+- `Linux`和`macOS`：存放在环境变量`TMPDIR`、`TMP`、`TEMP`指定的目录，缺省时为`/tmp`
+- `Windows`：存放在`C:\Users\<Username>\AppData\Local\Temp`
+
+**使用示例：**
+```bash
+# 启用INFO级别日志，使用默认临时文件
+quickswitch -v
+
+# 启用DEBUG级别日志，指定日志文件
+quickswitch -vv ./debug.log
+
+# 启用TRACE级别日志，指定日志文件
+quickswitch -vvv /tmp/quickswitch.log
+```
 
 ## 开发贡献
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use tracing::instrument;
 
 use crate::{
     app_state::AppState,
@@ -13,6 +14,7 @@ pub struct App {
 }
 
 impl App {
+    #[instrument]
     pub fn new(initial_mode: AppMode) -> Result<Self> {
         GLOBAL_PICKER.font_size();
         let mut state = AppState::new()?;

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,4 +1,5 @@
 use ratatui::widgets::ListState;
+use tracing::{debug, instrument, warn};
 use std::{collections::HashMap, path::PathBuf, time::Instant};
 
 use crate::{
@@ -27,8 +28,10 @@ pub struct AppState {
 }
 
 impl AppState {
+    #[instrument]
     pub fn new() -> anyhow::Result<Self> {
         let current_dir = std::env::current_dir()?;
+        debug!(dir = %current_dir.display(), "Build AppState");
         Ok(Self {
             search_input: String::new(),
             is_searching: false,
@@ -48,33 +51,49 @@ impl AppState {
     }
 
     /// Update the layout based on terminal size
+    #[instrument(skip(self))]
     pub fn update_layout(&mut self, terminal_size: ratatui::layout::Rect) {
+        debug!(width = terminal_size.width, height = terminal_size.height, "Updating layout");
         self.layout.update_layout(terminal_size);
     }
 
     /// Check if a point is in the left panel area
+    #[instrument(skip(self))]
     pub fn is_point_in_left_panel(&self, x: u16, y: u16) -> bool {
-        self.layout.is_in_left_area(x, y)
+        let result = self.layout.is_in_left_area(x, y);
+        debug!(x, y, result, "Checking if point is in left panel");
+        result
     }
 
     /// Check if a point is in the right panel area
+    #[instrument(skip(self))]
     pub fn is_point_in_right_panel(&self, x: u16, y: u16) -> bool {
-        self.layout.is_in_right_area(x, y)
+        let result = self.layout.is_in_right_area(x, y);
+        debug!(x, y, result, "Checking if point is in right panel");
+        result
     }
 
     /// Check if a point is in the search area
+    #[instrument(skip(self))]
     pub fn is_point_in_search_area(&self, x: u16, y: u16) -> bool {
-        self.layout.is_in_search_area(x, y)
+        let result = self.layout.is_in_search_area(x, y);
+        debug!(x, y, result, "Checking if point is in search area");
+        result
     }
 
     /// Load file items for Normal mode
+    #[instrument(skip(self, file_items), fields(item_count = file_items.len()))]
     pub fn load_file_items(&mut self, file_items: Vec<FileItem>) {
+        debug!("Loading {} file items", file_items.len());
         self.files = file_items.into_iter().map(DisplayItem::File).collect();
         self.reset_filter();
+        debug!("File items loaded successfully");
     }
 
     /// Reset filter and selection
+    #[instrument(skip(self))]
     pub fn reset_filter(&mut self) {
+        debug!("Resetting filter");
         self.filtered_files = self
             .files
             .iter()
@@ -83,10 +102,14 @@ impl AppState {
             .map(|(i, _)| i)
             .collect();
         self.file_list_state.select(None);
+        debug!("Filter reset, {} items visible", self.filtered_files.len());
     }
 
     /// Apply search filter to current items
+    #[instrument(skip(self), fields(search_term = %self.search_input))]
     pub fn apply_search_filter(&mut self) {
+        debug!("Applying search filter with term: '{}'", self.search_input);
+        
         if self.search_input.is_empty() {
             self.filtered_files = self
                 .files
@@ -112,22 +135,30 @@ impl AppState {
                 .collect();
         }
         self.file_list_state.select(None);
+        debug!("Search filter applied, {} items matched", self.filtered_files.len());
     }
 
     /// Get selected item
+    #[instrument(skip(self))]
     pub fn get_selected_item(&self) -> Option<DisplayItem> {
         if let Some(selected) = self.file_list_state.selected() {
             if let Some(&file_index) = self.filtered_files.get(selected) {
-                return self.files.get(file_index).cloned();
+                if let Some(item) = self.files.get(file_index).cloned() {
+                    debug!(item_name = %item.get_display_name(), "Selected item retrieved");
+                    return Some(item);
+                }
             }
         }
+        debug!("No item selected");
         None
     }
 
     /// Check if an item should be shown based on current filter settings
+    #[instrument(skip(self, item), fields(item = %item.get_display_name()))]
     fn should_show_item(&self, item: &DisplayItem) -> bool {
         // Always show non-file items (like history entries)
         if !matches!(item, DisplayItem::File(_)) {
+            debug!("Showing non-file item");
             return true;
         }
 
@@ -136,16 +167,22 @@ impl AppState {
         // Check if it's a hidden file (starts with '.')
         if name.starts_with('.') {
             // Show hidden files only if show_hidden_files is true
-            self.show_hidden_files
+            let should_show = self.show_hidden_files;
+            debug!(is_hidden = true, show_hidden_files = self.show_hidden_files, should_show, "Hidden file visibility check");
+            should_show
         } else {
             // Always show non-hidden files
+            debug!(is_hidden = false, should_show = true, "Non-hidden file, showing");
             true
         }
     }
 
     /// Toggle hidden files visibility and reapply filters
+    #[instrument(skip(self))]
     pub fn toggle_hidden_files(&mut self) {
+        let old_state = self.show_hidden_files;
         self.show_hidden_files = !self.show_hidden_files;
+        debug!(old_state, new_state = self.show_hidden_files, "Toggled hidden files visibility");
         self.apply_search_filter();
     }
 }

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,6 +1,6 @@
 use ratatui::widgets::ListState;
-use tracing::{debug, instrument, warn};
 use std::{collections::HashMap, path::PathBuf, time::Instant};
+use tracing::{debug, instrument, warn};
 
 use crate::{
     core::layout::LayoutManager,
@@ -53,7 +53,11 @@ impl AppState {
     /// Update the layout based on terminal size
     #[instrument(skip(self))]
     pub fn update_layout(&mut self, terminal_size: ratatui::layout::Rect) {
-        debug!(width = terminal_size.width, height = terminal_size.height, "Updating layout");
+        debug!(
+            width = terminal_size.width,
+            height = terminal_size.height,
+            "Updating layout"
+        );
         self.layout.update_layout(terminal_size);
     }
 
@@ -109,7 +113,7 @@ impl AppState {
     #[instrument(skip(self), fields(search_term = %self.search_input))]
     pub fn apply_search_filter(&mut self) {
         debug!("Applying search filter with term: '{}'", self.search_input);
-        
+
         if self.search_input.is_empty() {
             self.filtered_files = self
                 .files
@@ -135,7 +139,10 @@ impl AppState {
                 .collect();
         }
         self.file_list_state.select(None);
-        debug!("Search filter applied, {} items matched", self.filtered_files.len());
+        debug!(
+            "Search filter applied, {} items matched",
+            self.filtered_files.len()
+        );
     }
 
     /// Get selected item
@@ -168,11 +175,20 @@ impl AppState {
         if name.starts_with('.') {
             // Show hidden files only if show_hidden_files is true
             let should_show = self.show_hidden_files;
-            debug!(is_hidden = true, show_hidden_files = self.show_hidden_files, should_show, "Hidden file visibility check");
+            debug!(
+                is_hidden = true,
+                show_hidden_files = self.show_hidden_files,
+                should_show,
+                "Hidden file visibility check"
+            );
             should_show
         } else {
             // Always show non-hidden files
-            debug!(is_hidden = false, should_show = true, "Non-hidden file, showing");
+            debug!(
+                is_hidden = false,
+                should_show = true,
+                "Non-hidden file, showing"
+            );
             true
         }
     }
@@ -182,7 +198,11 @@ impl AppState {
     pub fn toggle_hidden_files(&mut self) {
         let old_state = self.show_hidden_files;
         self.show_hidden_files = !self.show_hidden_files;
-        debug!(old_state, new_state = self.show_hidden_files, "Toggled hidden files visibility");
+        debug!(
+            old_state,
+            new_state = self.show_hidden_files,
+            "Toggled hidden files visibility"
+        );
         self.apply_search_filter();
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use tracing::{debug, instrument};
 use std::{fs, path::PathBuf};
+use tracing::{debug, instrument};
 
 /// Get the data directory for quickswitch
 ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use tracing::{debug, instrument};
 use std::{fs, path::PathBuf};
 
 /// Get the data directory for quickswitch
@@ -65,6 +66,7 @@ fn get_default_data_dir() -> Result<PathBuf> {
 }
 
 /// Configuration for history functionality
+#[derive(Debug)]
 pub struct HistoryConfig {
     /// Maximum number of history entries to keep
     pub max_entries: usize,
@@ -77,13 +79,16 @@ pub struct HistoryConfig {
 }
 
 impl Default for HistoryConfig {
+    #[instrument]
     fn default() -> Self {
-        Self {
+        let config = Self {
             max_entries: 100,
             sort_mode: crate::utils::HistorySortMode::FrequencyRecent,
             time_decay_days: 30,
             min_frequency_threshold: 1,
-        }
+        };
+        debug!(?config, "Created default HistoryConfig");
+        config
     }
 }
 

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -3,7 +3,7 @@ use crossterm::{
     cursor::Show,
     event::{DisableMouseCapture, KeyEvent, MouseEvent},
     execute,
-    terminal::{disable_raw_mode, LeaveAlternateScreen},
+    terminal::{LeaveAlternateScreen, disable_raw_mode},
 };
 use std::{env, io};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod app_state;
 pub mod config;
 pub mod core;
+pub mod logging;
 pub mod modes;
 pub mod services;
 pub mod terminal;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -27,14 +27,13 @@ pub fn init_logging(verbose_level: u8, log_file: Option<&std::path::Path>) -> Re
         Some(path) => OpenOptions::new()
             .create(true)
             .append(true)
-            .write(true)
             .open(path)
             .map_err(|e| anyhow::anyhow!("Failed to open log file {:?}: {}", path, e))?,
         None => {
             let date = Local::now().format("%Y-%m-%d").to_string();
             let pid = std::process::id();
             let file = tempfile::Builder::new()
-                .prefix(&format!("qw-{}-{}-", date, pid))
+                .prefix(&format!("qw-{date}-{pid}-"))
                 .suffix(".log")
                 .rand_bytes(5)
                 .tempfile()?

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,66 @@
+use anyhow::{Ok, Result};
+use chrono::Local;
+use std::{env, fs::OpenOptions};
+use tracing::{instrument, warn};
+use tracing_appender::non_blocking;
+use tracing_subscriber::{EnvFilter, fmt::time::Uptime};
+
+#[instrument]
+pub fn init_logging(verbose_level: u8, log_file: Option<&std::path::Path>) -> Result<()> {
+    // set the default log level based on verbosity
+    let warn_tag = verbose_level > 3;
+    let filter = match verbose_level {
+        0 => {
+            if env::var("RUST_LOG").is_ok() {
+                EnvFilter::from_default_env()
+            } else {
+                return Ok(());
+            }
+        }
+        1 => EnvFilter::new("INFO"),
+        2 => EnvFilter::new("DEBUG"),
+        _ => EnvFilter::new("TRACE"),
+    };
+
+    // Initialize log file
+    let writer = match log_file {
+        Some(path) => OpenOptions::new()
+            .create(true)
+            .append(true)
+            .write(true)
+            .open(path)
+            .map_err(|e| anyhow::anyhow!("Failed to open log file {:?}: {}", path, e))?,
+        None => {
+            let date = Local::now().format("%Y-%m-%d").to_string();
+            let pid = std::process::id();
+            let file = tempfile::Builder::new()
+                .prefix(&format!("qw-{}-{}-", date, pid))
+                .suffix(".log")
+                .rand_bytes(5)
+                .tempfile()?
+                .keep()?;
+            file.0
+        }
+    };
+    let (appender, _guard) = non_blocking(writer);
+
+    tracing_subscriber::fmt()
+        .with_thread_ids(false)
+        .with_thread_names(false)
+        .with_target(false)
+        .with_file(true)
+        .with_line_number(true)
+        .with_timer(Uptime::default())
+        .with_writer(appender)
+        .with_env_filter(filter)
+        .init();
+
+    // Keep the guard alive for the duration of the program
+    std::mem::forget(_guard);
+
+    if warn_tag {
+        warn!("Invalid verbosity level. Defaulting to TRACE.");
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use clap::Parser;
 use quickswitch::{
-    Result, ShellType, qs_init, run_interactive_mode, run_non_interactive, utils::AppMode,
+    Result, ShellType, logging::init_logging, qs_init, run_interactive_mode, run_non_interactive,
+    utils::AppMode,
 };
+use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(
@@ -22,11 +24,22 @@ struct Cli {
     /// Initialize shell configuration (bash, zsh, fish, powershell, cmd)
     #[arg(long, value_enum)]
     init: Option<ShellType>,
+
+    /// Enable verbose logging (-v=INFO, -vv=DEBUG, -vvv=TRACE)
+    #[arg(short = 'v', action = clap::ArgAction::Count)]
+    verbose: u8,
+
+    /// Log file path (creates temp file `qw-[date]-[pid].log` if not specified)
+    #[arg(long)]
+    log_file: Option<PathBuf>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Initialize logging if verbose flag is set
+    init_logging(cli.verbose, cli.log_file.as_deref())?;
 
     // Handle init option
     if let Some(shell) = cli.init {

--- a/src/modes/history/data_provider.rs
+++ b/src/modes/history/data_provider.rs
@@ -142,7 +142,10 @@ impl HistoryDataProvider {
 
         // Apply max entries limit
         if entries.len() > config.max_entries {
-            info!("Trimming history entries to max limit: {}", config.max_entries);
+            info!(
+                "Trimming history entries to max limit: {}",
+                config.max_entries
+            );
             entries.truncate(config.max_entries);
         }
 

--- a/src/modes/history/data_provider.rs
+++ b/src/modes/history/data_provider.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use bincode::config;
 use std::{fs, path::PathBuf};
+use tracing::{error, info, instrument};
 
 use crate::{
     app_state::AppState,
@@ -11,6 +12,7 @@ use crate::{
 };
 
 /// Data provider for history list (History mode)
+#[derive(Debug)]
 pub struct HistoryDataProvider;
 
 impl HistoryDataProvider {
@@ -34,6 +36,7 @@ impl HistoryDataProvider {
     }
 
     /// Load history entries from file
+    #[instrument(skip(self))]
     fn load_history_entries(&self) -> Result<Vec<HistoryEntry>> {
         let file_path = self.get_history_file_path();
 
@@ -41,11 +44,12 @@ impl HistoryDataProvider {
         if file_path.exists() {
             let data = fs::read(&file_path)?;
             let config = config::standard();
+            info!(path = %file_path.display(), "Loading history data from file");
             match bincode::serde::decode_from_slice(&data, config) {
                 Ok((entries, _)) => return Ok(entries),
                 Err(e) => {
                     // If deserialization fails, try to migrate from legacy format
-                    eprintln!("Error loading history data: {e}");
+                    error!("Error loading history data: {e}");
                     if let Ok(entries) = self.migrate_from_legacy() {
                         return Ok(entries);
                     }
@@ -56,16 +60,19 @@ impl HistoryDataProvider {
 
         // If binary file doesn't exist, try to migrate from legacy format
         if self.get_legacy_history_file_path().exists() {
+            info!("Legacy history file found, migrating to new format");
             if let Ok(entries) = self.migrate_from_legacy() {
                 return Ok(entries);
             }
         }
 
         // If all else fails, return empty list
+        info!("No history data found, returning empty list");
         Ok(Vec::new())
     }
 
     /// Migrate from legacy text-based history format
+    #[instrument(skip(self))]
     fn migrate_from_legacy(&self) -> Result<Vec<HistoryEntry>> {
         let legacy_path = self.get_legacy_history_file_path();
         if let Ok(content) = fs::read_to_string(&legacy_path) {
@@ -83,6 +90,7 @@ impl HistoryDataProvider {
 
             // Backup the legacy file
             if legacy_path.exists() {
+                info!("Backing up legacy history file to .bak");
                 let backup_path = legacy_path.with_extension("history.bak");
                 let _ = fs::rename(&legacy_path, backup_path);
             }
@@ -94,6 +102,7 @@ impl HistoryDataProvider {
     }
 
     /// Save history entries to file
+    #[instrument(skip(self, entries))]
     fn save_history_entries(&self, entries: &[HistoryEntry]) -> Result<()> {
         let config = config::standard();
         let data = bincode::serde::encode_to_vec(entries, config)?;
@@ -102,15 +111,17 @@ impl HistoryDataProvider {
         // Ensure directory exists
         if let Some(parent) = file_path.parent() {
             if !parent.exists() {
+                info!(path = %parent.display(), "Creating directory for history file");
                 fs::create_dir_all(parent)?;
             }
         }
-
+        info!(path = %file_path.display(), "Saving history data to file");
         fs::write(file_path, data)?;
         Ok(())
     }
 
     /// Add a path to history or update its frequency if it already exists
+    #[instrument(skip(self), fields(path = %path.display()))]
     pub fn add_to_history(&self, path: PathBuf) -> Result<()> {
         let mut entries = self.load_history_entries()?;
         let config = get_history_config();
@@ -119,17 +130,19 @@ impl HistoryDataProvider {
         let existing_index = entries.iter().position(|entry| entry.path == path);
 
         if let Some(index) = existing_index {
-            // Update existing entry
+            info!(path = %path.display(), "Updating frequency for existing history entry: {}", path.display());
             let mut entry = entries.remove(index);
             entry.increment_frequency();
             entries.insert(0, entry); // Move to top
         } else {
             // Add new entry
+            info!(path = %path.display(), "Adding new history entry: {}", path.display());
             entries.insert(0, HistoryEntry::new(path));
         }
 
         // Apply max entries limit
         if entries.len() > config.max_entries {
+            info!("Trimming history entries to max limit: {}", config.max_entries);
             entries.truncate(config.max_entries);
         }
 
@@ -139,6 +152,7 @@ impl HistoryDataProvider {
     }
 
     /// Get sorted history entries based on the configured sort mode
+    #[instrument(skip(self))]
     pub fn get_sorted_entries(&self, sort_mode: &HistorySortMode) -> Result<Vec<HistoryEntry>> {
         let mut entries = self.load_history_entries()?;
         let config = get_history_config();
@@ -177,7 +191,7 @@ impl HistoryDataProvider {
             }
         }
 
-        // Filter out entries that don't exist anymore
+        info!("Filtering out non-existent history entries");
         entries.retain(|entry| entry.path.exists());
 
         Ok(entries)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,11 +6,11 @@ use ratatui::{
     text::Span,
 };
 use serde::{Deserialize, Serialize};
-use tracing::{debug, instrument, error};
 use std::{
     io::IsTerminal,
     path::{Path, PathBuf},
 };
+use tracing::{debug, error, instrument};
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum ShellType {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,6 +6,7 @@ use ratatui::{
     text::Span,
 };
 use serde::{Deserialize, Serialize};
+use tracing::{debug, instrument, error};
 use std::{
     io::IsTerminal,
     path::{Path, PathBuf},
@@ -225,6 +226,7 @@ pub fn run_non_interactive() -> Result<()> {
 }
 
 // Init Bash and Zsh functions for quickswitch
+#[instrument]
 fn qs_init_bash_zsh() -> Result<()> {
     let bash_init = r#"
 qs() {
@@ -244,10 +246,12 @@ qshs() {
 }
     "#;
     println!("{bash_init}");
+    debug!("{bash_init}");
 
     Ok(())
 }
 
+#[instrument]
 fn qs_init_fish() -> Result<()> {
     let fish_init = r#"
 function qs
@@ -279,10 +283,12 @@ function qshs
 end
     "#;
     println!("{fish_init}");
+    debug!("{fish_init}");
 
     Ok(())
 }
 
+#[instrument]
 fn qs_init_powershell() -> Result<()> {
     let powershell_init = r#"
 function qs {
@@ -306,11 +312,14 @@ function qshs {
 }
     "#;
     println!("{powershell_init}");
+    debug!("{powershell_init}");
 
     Ok(())
 }
 
+#[instrument]
 fn qs_init_cmd() -> Result<()> {
+    error!("CMD initialization is not implemented yet. Please use PowerShell or another shell.");
     todo!("CMD initialization is not implemented yet");
 }
 


### PR DESCRIPTION
（以下说明和README一样）

日志功能由[tracing](https://github.com/tokio-rs/tracing)实现，使用以下参数启动日志。有关日志级别详见[tracing::Level](https://docs.rs/tracing/latest/tracing/struct.Level.html)。

**日志级别参数：**
- `-v/--verbose` 收集INFO级别日志
- `-vv` 收集DEBUG级别日志
- `-vvv` 收集TRACE级别日志

**日志文件路径：**
- `-v/-vv/-vvv/--verbose` 在设定日志级别的同时指定日志文件路径

**环境变量支持：**
你也可以使用类似[env-logger](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)的环境变量指示日志级别（大小写忽略，不支持模块定向级别，环境变量优先级低于命令行参数）。

**日志文件说明：**
日志只能存放在文件中，日志路径不可用时将直接退出。文件不存在将被创建，若已存在将尝试追加。参数缺省时通过[tempfile](https://docs.rs/tempfile/latest/tempfile/)库创建临时文件，文件名格式为`qw-[date]-[pid]-[rand].log`。

- `Linux`和`macOS`：存放在环境变量`TMPDIR`、`TMP`、`TEMP`指定的目录，缺省时为`/tmp`
- `Windows`：存放在`C:\Users\<Username>\AppData\Local\Temp`

**使用示例：**
```bash
# 启用INFO级别日志，使用默认临时文件
quickswitch -v

# 启用DEBUG级别日志，指定日志文件
quickswitch -vv --log_file ./debug.log

```